### PR TITLE
Make the IP detection work also if the web server is behind a proxy

### DIFF
--- a/wpml-geoip-browser-language-redirect.php
+++ b/wpml-geoip-browser-language-redirect.php
@@ -91,8 +91,12 @@ class WPML_GeoIP_Browser_Language_Redirect
 			$ipr = new WPML_GeoIP_IPResolver();
 
 			$ipr->set_json_header();
-			$tmp_ip = $_SERVER['REMOTE_ADDR'];
-			echo $ipr->ip_to_wpml_country_code($_SERVER['REMOTE_ADDR']);
+			if (array_key_exists('HTTP_X_FORWARDED_FOR', $_SERVER)) {
+				$tmp_ip = explode(',', $_SERVER['HTTP_X_FORWARDED_FOR'])[0];
+			} else {
+				$tmp_ip = $_SERVER['REMOTE_ADDR'];
+			}
+			echo $ipr->ip_to_wpml_country_code($tmp_ip);
 			die();
 		}
 	}


### PR DESCRIPTION
If the web server is behind a proxy $_SERVER['REMOTE_ADDR'] doesn't contain the IP address of the client, but the IP of the proxy itself, so the geolocation doesn't work as expected.

In that cases a de-facto standard between proxies is to insert the [X-Forwarded-For header](http://en.wikipedia.org/wiki/X-Forwarded-For) in the request headers.

The patch uses that header, if present.