### PR TITLE
[Issue #2] Settings page added to make language mapping easier

### DIFF
--- a/WPML_GEOIP_admin_page.class.php
+++ b/WPML_GEOIP_admin_page.class.php
@@ -1,0 +1,217 @@
+<?php
+if( ! defined( 'ABSPATH' ) ) exit;
+
+class WPML_geoip_admin_page
+{
+	var $language_mappings;
+	var $default_language;
+
+	
+	function __construct( $language_mappings , $default_language ){
+		$this->language_mappings = $language_mappings;
+		$this->default_language  = $default_language;
+	}
+	
+
+	function display_wpml_geo_redirect_admin_page(){
+		?>
+
+		<div class="wrap">
+			<div id="icon-plugins" class="icon32"></div>
+			<h2>WPML GEO Redirect</h2>
+
+			<?php $this->display_feedback_admin_notices() ?>
+
+			<form method="post" action="options-general.php?page=wpml_geo_redirect_settings" id="options_form" >
+				<?php
+				echo '<table class="form-table" >';
+				echo "<tr>
+						<td>Country Code / Language Code</td>
+							<td width='83%'>Remove</td>
+						</tr>";
+				$table_row = $this->display_language_mapping_rows( $this->language_mappings );
+	
+				$this->display_add_new_country_mapping_row( $table_row );
+				$this->display_select_default_language_row( $table_row , $this->default_language );
+				echo "</table>";
+	
+				wp_nonce_field( 'wpml_geo_redirect_update_action' );
+				submit_button();
+				?>
+			</form>
+		</div>
+
+		<?php
+	}
+	
+
+	// Helpers ///////////////////////////////////////////////////////////////////////////////////////////////////
+
+	private function display_feedback_admin_notices(){
+
+		if( isset($_GET['feedback'] ) ){
+
+			$feedback = trim( $_GET['feedback'] );
+			switch( $feedback ){
+
+				case 'success':
+					?>
+					<div class="notice notice-success is-dismissible">
+						<p>Configuration data was updated.</p>
+					</div>
+					<?php
+					break;
+
+				case 'duplicate_key':
+					?>
+					<div class="notice notice-error is-dismissible">
+						<p>There has been an error. Country codes need to be unique.</p>
+					</div>
+					<?php
+					break;
+
+				case 'form_submission_error':
+					?>
+					<div class="notice notice-error is-dismissible">
+						<p>There has been a form submission error.</p>
+					</div>
+					<?php
+					break;
+			}
+		}
+	}
+
+
+	private function display_language_mapping_rows( $language_mappings ){
+
+		$table_row = 0;
+
+		foreach( $language_mappings as $country_code => $lang_code){
+
+			echo '<tr valign="top">';
+			echo '<td>';
+			echo $this->display_icl_language_flag( $country_code );
+			echo "&nbsp;";
+			echo $this->display_mm_country_code_dropdown( $table_row , $country_code );
+			echo "<strong> => </strong>";
+			echo $this->display_language_code_dropdown( $table_row , $lang_code );
+			echo '</td>';
+			echo '<td>';
+			echo '<input type="checkbox" name="remove_country_code['.$table_row.']" value="' . $country_code . '">';
+			echo '</td>';
+			echo '</tr>';
+
+			$table_row++;
+		}
+		return $table_row;
+	}
+
+
+	private function display_icl_language_flag( $country_code ){
+
+		if( defined( 'WPML_GEO_REDIRECT_SHOW_FLAGS' ) &&
+		    file_exists( ICL_PLUGIN_PATH . '/res/flags/' . strtolower( $country_code ) .'.png' )){
+
+			$url = ICL_PLUGIN_URL . '/res/flags/' . strtolower( $country_code ) .'.png';
+			return $img_tag = '<img width="18" height="12" alt="'.$country_code.'" src="' . $url . '" />';
+		}
+		return false;
+	}
+
+
+	private function display_mm_country_code_dropdown( $table_row=0 , $country_code_param=null , $remove_saved_codes=false ){
+
+		$mm_country_codes = array(
+			'AP','EU','AD','AE','AF','AG','AI','AL','AM','CW','AO','AQ','AR','AS','AT','AU','AW','AZ','BA','BB','BD','BE','BF','BG',
+			'BH','BI','BJ','BM','BN','BO','BR','BS','BT','BV','BW','BY','BZ','CA','CC','CD','CF','CG','CH','CI','CK','CL','CM','CN',
+			'CO','CR','CU','CV','CX','CY','CZ','DE','DJ','DK','DM','DO','DZ','EC','EE','EG','EH','ER','ES','ET','FI','FJ','FK','FM',
+			'FO','FR','SX','GA','GB','GD','GE','GF','GH','GI','GL','GM','GN','GP','GQ','GR','GS','GT','GU','GW','GY','HK','HM','HN',
+			'HR','HT','HU','ID','IE','IL','IN','IO','IQ','IR','IS','IT','JM','JO','JP','KE','KG','KH','KI','KM','KN','KP','KR','KW',
+			'KY','KZ','LA','LB','LC','LI','LK','LR','LS','LT','LU','LV','LY','MA','MC','MD','MG','MH','MK','ML','MM','MN','MO','MP',
+			'MQ','MR','MS','MT','MU','MV','MW','MX','MY','MZ','NA','NC','NE','NF','NG','NI','NL','NO','NP','NR','NU','NZ','OM','PA',
+			'PE','PF','PG','PH','PK','PL','PM','PN','PR','PS','PT','PW','PY','QA','RE','RO','RU','RW','SA','SB','SC','SD','SE','SG',
+			'SH','SI','SJ','SK','SL','SM','SN','SO','SR','ST','SV','SY','SZ','TC','TD','TF','TG','TH','TJ','TK','TM','TN','TO','TL',
+			'TR','TT','TV','TW','TZ','UA','UG','UM','US','UY','UZ','VA','VC','VE','VG','VI','VN','VU','WF','WS','YE','YT','RS','ZA',
+			'ZM','ME','ZW','AX','GG','IM','JE','BL','MF','BQ','SS'
+		);
+
+		/* For new country row - no need to show codes already used */
+		if( $remove_saved_codes ){
+			$mm_country_codes = array_diff( $mm_country_codes , array_keys( $this->language_mappings ) );
+		}
+
+		asort( $mm_country_codes );
+
+		$select_name    = 'language_mappings[' . $table_row . '][country]';
+		$output         = '<select name="' . $select_name . '" >';
+		$output         .= "<option value='country_code_ddown_label'>Country Code</option>";
+		
+		foreach( $mm_country_codes as $country_code ) {
+
+			$selected = $this->selected_html( $country_code , $country_code_param );
+
+			$output .= "<option {$selected} >{$country_code}</option>";
+		}
+
+		$output .= "</select>";
+
+		return $output;
+	}
+
+
+	private function selected_html( $value_1 , $value_2 ){
+		return $selected = ($value_1 == $value_2 ? 'selected="selected"' : null);
+	}
+	
+	
+	private function display_language_code_dropdown( $table_row=0 , $lang_code_param='' , $is_default=false ){
+
+		global $sitepress_settings;
+
+		$args['skip_missing'] = intval($sitepress_settings['automatic_redirect'] == 1);
+		$languages = apply_filters( 'wpml_active_languages', null, $args );
+
+		$select_name = $is_default === true ? 'default_redirect_language' : 'language_mappings['. $table_row .'][language]';
+
+		$output = '<select name="' . $select_name . '" >';
+
+		foreach( $languages as $language ) {
+
+			$selected = $this->selected_html( $language['code'] , $lang_code_param );
+			$output .= "<option {$selected} >{$language['code']}</option>";
+		}
+
+		$output .= "</select>";
+
+		return $output;
+	}
+
+
+	private function display_add_new_country_mapping_row( $table_row ){
+
+		echo '<tr valign="top" style="border-top: dotted black 2px;">';
+		echo '<td>';
+		echo $this->display_mm_country_code_dropdown( $table_row, null, true );
+		echo "<strong> => </strong>";
+		echo $this->display_language_code_dropdown( $table_row );
+		echo '</td>';
+		echo '<td>';
+		echo "&nbsp;";
+		echo '</td>';
+		echo '</tr>';
+
+	}
+
+
+	private function display_select_default_language_row( $table_row , $default_language ){
+
+		echo '<tr valign="top" style="border-top: dotted black 2px;">';
+		echo '<td colspan="2">';
+		echo "Any other place on this planet";
+		echo "<strong> => </strong>";
+		echo $this->display_language_code_dropdown( $table_row , $default_language , true );
+		echo '</td>';
+		echo '</tr>';
+
+	}
+}

--- a/WPML_GeoIP_IPResolver.class.php
+++ b/WPML_GeoIP_IPResolver.class.php
@@ -31,6 +31,7 @@ class WPML_GeoIP_IPResolver
 		 */
 
 		//Array with structure MaxMind Code => WPML Code
+		/*
 		$this->language_mappings = array(
 			'SE' => 'sv', //Sweden
 			'NO' => 'nb', //Norway
@@ -38,10 +39,13 @@ class WPML_GeoIP_IPResolver
 			'DK' => 'da', //Denmark
 			'US' => 'en', //USA
 			'CA' => 'en'  //Canada
-		);
+		); */
+
+		$this->language_mappings = get_option( 'wpml_geo_redirect_language_mappings' );
 
 		//Set the default WPML language which is used if no matching language is found
-		$this->default_language = 'sv';
+		//$this->default_language = 'sv';
+		$this->default_language = get_option( 'wpml_geo_redirect_default_language' );
 		
 		//Make sure to not redeclare the GeoIP API if it is loaded already.
 		if(!function_exists('geoip_country_code_by_addr')) 


### PR DESCRIPTION
Issue: https://github.com/khromov/wp-wpml-geoip-browser-language-redirect/issues/20

I've worked also an branch with more AJAX  and Settings API. 
But in the end, after some testing, this code here appeared to be the most robust.
Hope you like it :-)